### PR TITLE
Endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ app.get('/api/v1/open_mic_performers', (request, response) => {
         })
 })
 
-app.post('/api/v1/open_mic_performers', (request, response) =>{
+app.post('/api/v1/open_mic_performers', (request, response) => {
     const performer = request.body;
 
     for (let requiredParameter of ['name']) {
@@ -35,6 +35,25 @@ app.post('/api/v1/open_mic_performers', (request, response) =>{
         })
         .catch(error => {
             response.status(500).json({ error })
+        })
+})
+
+app.delete('/api/v1/open_mic_performers/:name', (request, response) => {
+    let { name } = request.params;
+    name = name.replace(/\+/g, " ");
+
+    database('performers')
+        .where('name', name)
+        .del()
+        .then(performer => {
+            if(performer === 0){
+                response.status(404).json(`No performer '${name}' found in database`);
+            } else {
+                response.status(202).json(`Performer '${name}' successfully removed`);
+            }
+        })
+        .catch(error => {
+            response.status(500).json({ error: error.message})
         })
 })
 

--- a/server.js
+++ b/server.js
@@ -38,3 +38,6 @@ app.post('/api/v1/open_mic_performers', (request, response) =>{
         })
 })
 
+app.listen(app.get('port'), () => {
+    console.log(`MicCheck is running on ${app.get('port')}`)
+})

--- a/server.js
+++ b/server.js
@@ -14,4 +14,27 @@ app.get('/api/v1/open_mic_performers', (request, response) => {
         .then(performers => {
             response.status(200).json(performers)
         })
+        .catch((error) => {
+            response.status(500).json({error})
+        })
 })
+
+app.post('/api/v1/open_mic_performers', (request, response) =>{
+    const performer = request.body;
+
+    for (let requiredParameter of ['name']) {
+        if(!performer[requiredParameter]) {
+            return response.status(422).send({
+                error: `Expected format: { name: <STRING> } missing ${requiredParameter}`
+            })
+        }
+    }
+    database('performers').insert(performer, 'id')
+        .then(performer => {
+            response.status(201).json({id: performer[0]})
+        })
+        .catch(error => {
+            response.status(500).json({ error })
+        })
+})
+


### PR DESCRIPTION
Wrote endpoints for Posting a performer to the database and for deleting a performer from the database. These endpoints need to be tested and an endpoint for deleting all performers needs to also be created. Will need to do some research as I've yet to make a delete that would delete everything. I will look into this today and hopefully complete that and testing today or tomorrow so that I can begin building out the front-end. 

Do we also want a multi-select delete, where multiple performers but not all performers will be deleted? would this be easier or would this just be something to do on the front-end where each performer to be deleted would be an individual fetch call for a deletion? Would probably be more taxing on the system that way. We'll see