### PR TITLE
Add and pass test for error with post request due to missing properties

### DIFF
--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -100,6 +100,22 @@ describe('Server file', () => {
                     done()
                 })
         })
+
+        it('post request should return error message if missing name', done => {
+            const newPerformer = {
+
+            }
+
+            chai
+                .request(app)
+                .post('/api/v1/open_mic_performers')
+                .send(newPerformer)
+                .end((error, response) => {
+                    expect(response).to.have.status(422);
+                    expect(response.error.text).to.equal(`{"error":"Expected format: { name: <STRING> } missing name"}`)
+                    done()
+                })
+        })
     })
     process.removeAllListeners()
 })


### PR DESCRIPTION
Added a test to ensure that an error message is sent when improperly formatting a post request. Test is passing and code is secure.